### PR TITLE
Bugfix; addition of cluster_fullness

### DIFF
--- a/lib/solidfire_api/cluster.rb
+++ b/lib/solidfire_api/cluster.rb
@@ -1,7 +1,7 @@
 ##
 # Cluster
-# 
-# Cluster related API calls 
+#
+# Cluster related API calls
 #
 
 module Cluster
@@ -21,7 +21,7 @@ module Cluster
 
   ##
   # Cluster Information such as hostname, mvip,svip,...
-  #  
+  #
   def cluster_info()
     api_call = {
       :method => "GetClusterInfo",
@@ -31,7 +31,19 @@ module Cluster
     answer = query_sf(api_call)
     return answer["clusterInfo"]
   end
-  
+
+  ##
+  # Cluster fullness information
+  #
+  def cluster_fullness()
+    api_call = {
+      :method => "GetClusterFullThreshold",
+      :params => {}
+    }
+    answer = query_sf(api_call)
+    return answer
+  end
+
   ##
   # Cluster firmware version including nodes
   #
@@ -43,10 +55,10 @@ module Cluster
     }
     answer = query_sf(api_call)
     return answer["clusterVersion"]
-  end  
+  end
   ##
   # Cluster performance metrics, overall IOPS,..
-  #  
+  #
   def cluster_stats()
     api_call = {
       :method => "GetClusterStats",
@@ -55,10 +67,10 @@ module Cluster
     }
     answer = query_sf(api_call)
     return answer["clusterStats"]
-  end  
+  end
 
   ##
-  # Cluster capacity 
+  # Cluster capacity
   #
   def cluster_capacity()
     api_call = {
@@ -67,7 +79,7 @@ module Cluster
       }
     }
     answer = query_sf(api_call)["clusterCapacity"]
-    
+
     # thinProvisioningFactor metric, calculated based on document instructions.
     # if condition to avoid divide by 0.
     if answer["nonZeroBlocks"] == 0
@@ -76,7 +88,7 @@ module Cluster
       answer["thinProvisioningFactor"] = (answer["nonZeroBlocks"] + answer["zeroBlocks"]) / answer["nonZeroBlocks"].to_f
       answer["thinProvisioningFactor"] = answer["thinProvisioningFactor"].round(2)
     end
-    
+
     # deDuplicationFactor metric, calculated based on document instructions.
     # if condition to avoid divide by 0.
     if answer["uniqueBlocks"] == 0
@@ -85,7 +97,7 @@ module Cluster
       answer["deDuplicationFactor"] = answer["nonZeroBlocks"] / answer["uniqueBlocks"].to_f
       answer["deDuplicationFactor"] = answer["deDuplicationFactor"].round(2)
     end
-    
+
     # compressionFactor metric, calculated based on document instructions.
     # if condition to avoid divide by 0.
     if answer["uniqueBlocksUsedSpace"] == 0
@@ -94,23 +106,23 @@ module Cluster
       answer["compressionFactor"] = (answer["uniqueBlocks"] * 4096) / answer["uniqueBlocksUsedSpace"].to_f
       answer["compressionFactor"] = answer["compressionFactor"].round(2)
     end
-    
+
     # efficiencyFactor metric, calculated based on document instructions.
     # efficiencyFactor = thinProvisioningFactor * deDuplicationFactor * compressionFactor
     answer["efficiencyFactor"] = answer["thinProvisioningFactor"] * answer["deDuplicationFactor"] * answer["compressionFactor"]
     answer["efficiencyFactor"] = answer["efficiencyFactor"].round(2)
-    
-    return answer
-  end 
-  
 
-  
+    return answer
+  end
+
+
+
   ##
   # List all account, return Array of Hash
   #
   # Arguments:
   #   limit: (integer, default=1000)
-  #  
+  #
   def accounts_list(limit = 1000)
     api_call = {
       :method => "ListAccounts",
@@ -125,7 +137,7 @@ module Cluster
 
   ##
   # List Cluster Faults
-  # 
+  #
   # Arguments:
   #  fault_type: (node,drive,cluster,service, default=all)
   #       node: Fault affecting an entire node
@@ -145,7 +157,7 @@ module Cluster
 
   ##
   # Cluster List iSCSI sessions.
-  #  
+  #
   def iscsi_sessions_list()
     api_call = {
       :method => "ListISCSISessions",
@@ -157,4 +169,3 @@ module Cluster
 
 
 end
-

--- a/lib/solidfire_api/connection.rb
+++ b/lib/solidfire_api/connection.rb
@@ -5,9 +5,9 @@ require 'solidfire_api/cluster'
 require 'solidfire_api/volume_access_group'
 
 module SolidfireApi
-  
+
   ##
-  # Object connection 
+  # Object connection
   #
   # Call using:  SolidfireApi::Connection.new({...})
   #
@@ -15,13 +15,13 @@ module SolidfireApi
   #   mvip: (String)
   #   username: (String)
   #   password: (String)
-  # 
-  class Connection    
+  #
+  class Connection
     include Cluster
     include Volume
     include Node
     include VolumeAccessGroup
-    
+
     def self.data
       @data ||= Hash.new do |hash, key|
         hash[key] = {}
@@ -31,9 +31,9 @@ module SolidfireApi
     def self.reset
       @data = nil
     end
-    
+
     ##
-    # 
+    #
     # Used by all other methods to connect at the SolidFire API
     # require RestClient gem to handle Rest API calls.
     # the input is the complete API query as Hash, the method will
@@ -47,17 +47,19 @@ module SolidfireApi
     #   >> }
     #   >> query_sf(api_call)
     #
-    # 
+    #
     # Arguments:
     #   query: (Hash)
     #      must include the complete Solidfire API query string.
     def query_sf(query)
       # query is a hash that is post in json format to SolidFire API.
-      solidfire_rest_url = "https://#{@username}:#{@password}@#{@mvip}/json-rpc/8.0"
+      solidfire_rest_url = "https://#{@mvip}/json-rpc/8.0"
 
       conn = RestClient::Resource.new(
         solidfire_rest_url,
-        :verify_ssl => @verify_ssl
+        :verify_ssl => @verify_ssl,
+        :user => @username,
+        :password => @password
       )
       result = JSON.parse(conn.post query.to_json)
 
@@ -67,10 +69,10 @@ module SolidfireApi
         else
           return result["error"]
         end
-      else 
+      else
         return result["result"]
       end
-    end 
+    end
 
     def initialize(options={})
       @mvip = options[:mvip]
@@ -96,14 +98,14 @@ module SolidfireApi
     def name
       @name
     end
-    
+
     def mvip
       @mvip
     end
-    
+
     def svip
       @svip
     end
-    
-  end    
+
+  end
 end


### PR DESCRIPTION
Added cluster_fullness method for accessing the result of GetClusterFullThreshold; pass the username and password as options to RestClient::Resource.new() to avoid issues where passwords with certain characters can't be parsed by uri (such as @ signs)

It looks like my editor automatically removed some superfluous whitespace, which makes the diff a bit hard to read. The important parts are:

```
@@ -47,17 +47,19 @@ module SolidfireApi
     #   >> }
     #   >> query_sf(api_call)
     #
-    #
+    #
     # Arguments:
     #   query: (Hash)
     #      must include the complete Solidfire API query string.
     def query_sf(query)
       # query is a hash that is post in json format to SolidFire API.
-      solidfire_rest_url = "https://#{@username}:#{@password}@#{@mvip}/json-rpc/8.0"
+      solidfire_rest_url = "https://#{@mvip}/json-rpc/8.0"

       conn = RestClient::Resource.new(
         solidfire_rest_url,
-        :verify_ssl => @verify_ssl
+        :verify_ssl => @verify_ssl,
+        :user => @username,
+        :password => @password
       )
       result = JSON.parse(conn.post query.to_json)

```

and

```
@@ -31,7 +31,19 @@ module Cluster
     answer = query_sf(api_call)
     return answer["clusterInfo"]
   end
-
+
+  ##
+  # Cluster fullness information
+  #
+  def cluster_fullness()
+    api_call = {
+      :method => "GetClusterFullThreshold",
+      :params => {}
+    }
+    answer = query_sf(api_call)
+    return answer
+  end
+
   ##
   # Cluster firmware version including nodes
   #
```
